### PR TITLE
add text helper functions for wrapping/paginating

### DIFF
--- a/pdDialogue.lua
+++ b/pdDialogue.lua
@@ -117,7 +117,7 @@ function pdDialogue.process(text, width, height, font)
         font = playdate.graphics.getFont()
     end
     -- Split newlines in text
-    for line in text:gmatch("[^\r\n]+") do
+    for line in text:gmatch("(.-)\n") do
         table.insert(lines, line)
     end
     local wrapped = pdDialogue.wrap(lines, width, font)


### PR DESCRIPTION
This is mostly just the gist script I wrote, with some updates:
* added comments
* renamed to use `pdDialogue`
* most functions now take an optional `font` parameter
* functions now take window/height in pixels and it calculates the row count as needed